### PR TITLE
armour model changes

### DIFF
--- a/src/model/Armour.java
+++ b/src/model/Armour.java
@@ -5,6 +5,7 @@ public class Armour {
     String  health
     String  type;
     boolean damaged;
+    boolean active;
 
     public String getWeight() {
         return weight;
@@ -34,5 +35,13 @@ public class Armour {
 
     public void setDamaged(boolean damage) {
         damaged = damage;
+    }
+
+    public boolean isActive() {
+        return active;
+    }
+
+    public void setActive(boolean active) {
+        this.active = active;
     }
 }


### PR DESCRIPTION
@michaelcatt not sure what you think about taking out health
also, for weight, since i'm fairly certain that weight for both weapon and armour will be LIGHT, MEDIUM or HEAVY, that we should just rename the enum to Weight or something so we can use it for both armour and weapons
(`ArmourWeaponWeight` maybe?)
